### PR TITLE
escape $ in .travis.yml

### DIFF
--- a/src/main/g8/.travis.yml
+++ b/src/main/g8/.travis.yml
@@ -8,4 +8,4 @@ scala:
    - 2.13.0-M4
 
 script:
-   - sbt ++$TRAVIS_SCALA_VERSION test
+   - sbt ++\$TRAVIS_SCALA_VERSION test


### PR DESCRIPTION
Fixes
```
$ g8 scalaz/scalaz-library.g8 --name=scalaz-test --description=desc
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/local/Cellar/giter8/0.11.0/libexec/conscript/boot/scala-2.10.7/org.foundweekends.giter8/giter8/0.11.0/slf4j-log4j12-1.7.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/local/Cellar/giter8/0.11.0/libexec/conscript/boot/scala-2.10.7/org.foundweekends.giter8/giter8/0.11.0/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]

Exiting due to error in the template: /var/folders/dx/5_0bxbrd4rg6lqg0t66b_4b00000gn/T/giter8-630017893110305
File: /var/folders/dx/5_0bxbrd4rg6lqg0t66b_4b00000gn/T/giter8-630017893110305/src/main/g8/.travis.yml, 11:33: 'test' came as a complete surprise to me
```